### PR TITLE
Update links + add window.pelagus prop

### DIFF
--- a/docs/develop/api/json-rpc-api.md
+++ b/docs/develop/api/json-rpc-api.md
@@ -4,7 +4,7 @@ title: JSON-RPC API
 description: Reference for the Pelagus JSON-RPC API.
 ---
 
-Pelagus uses the [`window.ethereum.request(args)`](quai-provider.md#windowethereumrequestargs) method to wrap a JSON-RPC API. The API contains both the standard Quai JSON-RPC API methods Pelagus specific methods. The API is exposed to the browser via the `window.ethereum` object.
+Pelagus uses the [`window.pelagus.request(args)`](quai-provider.md#windowpelagusrequestargs) method to wrap a JSON-RPC API. The API contains both the standard Quai JSON-RPC API methods Pelagus specific methods. The API is exposed to the browser via the `window.pelagus` object.
 
 ## Methods
 
@@ -16,13 +16,13 @@ Pelagus supports the following Pelagus specific API methods:
 - [personal_sign](#personal_sign)
 - [quai_signTypedData_v4](#quai_signtypeddata_v4)
 
-Pelagus also supports most standard Quai JSON-RPC API methods. For a full list of supported methods, see the [Quai JSON-RPC API documentation](https://docs.quai.network/develop/apis/json-rpc). Relevant supported methods include:
+Pelagus also supports most standard Quai JSON-RPC API methods. For a full list of supported methods, see the [Quai JSON-RPC API documentation](https://docs.qu.ai/build/playground/overview). Relevant supported methods include:
 
-- [quai_chainId](https://docs.quai.network/develop/apis/json-rpc#quai_chainid)
-- [quai_getBalance](https://docs.quai.network/develop/apis/json-rpc#quai_getbalance)
-- [quai_getTransactionCount](https://docs.quai.network/develop/apis/json-rpc#quai_gettransactioncount)
-- [quai_getBlockByNumber](https://docs.quai.network/develop/apis/json-rpc#quai_getblockbynumber)
-- [quai_getBlockByHash](https://docs.quai.network/develop/apis/json-rpc#quai_getblockbyhash)
+- [quai_chainId](https://docs.qu.ai/build/playground/other/chainId)
+- [quai_getBalance](https://docs.qu.ai/build/playground/addresses/getBalance)
+- [quai_getTransactionCount](https://docs.qu.ai/build/playground/addresses/getTransactionCount)
+- [quai_getBlockByNumber](https://docs.qu.ai/build/playground/blocks/getBlockByNumber)
+- [quai_getBlockByHash](https://docs.qu.ai/build/playground/blocks/getBlockByHash)
 
 :::tip
 **RPC method requests may return an error**.
@@ -41,7 +41,7 @@ The `quai_requestAccounts` method **initiates an extension pop-up** that prompts
 
 ```js
 const requestAccounts = async () => {
-	await window.ethereum
+	await window.pelagus
 		.request({ method: 'quai_requestAccounts' })
 		.then((accounts) => {
 			console.log('Accounts:', accounts)
@@ -64,7 +64,7 @@ If the user accepts the request, `quai_requestAccounts` returns an array of hexi
 An example of a return value from the [`quai_requestAccounts`] method:
 
 ```
-['0x5a62de2c3f3803b3407cabc24e296d91cf977566']
+['0x002F4783248e2D6FF1aa6482A8C0D7a76de3C329']
 ```
 
 ### quai_accounts
@@ -79,7 +79,7 @@ An example of a return value from the [`quai_requestAccounts`] method:
 
 ```js
 const getAccounts = async () => {
-	await window.ethereum
+	await window.pelagus
 		.request({ method: 'quai_accounts' })
 		.then((accounts) => {
 			console.log('Accounts:', accounts)
@@ -118,13 +118,13 @@ All data passed to the `quai_sendTransaction` method as a parameter must be a **
 
 ```js
 const sendTransaction = async () => {
-	await window.ethereum
+	await window.pelagus
 		.request({
 			method: 'quai_sendTransaction',
 			params: [
 				{
-					from: '0xb60e8dd61c5d32be8058bb8eb970870f07233155',
-					to: '0xd46e8dd67c5d32be8058bb8eb970870f07244567',
+					from: '0x002F4783248e2D6FF1aa6482A8C0D7a76de3C329',
+					to: '0x005f644097F8f0E9f996Dca4F4F23aBB6C1Cc8b3',
 					gas: '0x5208',
 					maxFeePerGas: '0x9184e72a000',
 					maxPriorityFeePerGas: '0x9184e72a000',
@@ -164,9 +164,9 @@ The `personal_sign` method accepts the following parameters:
 const signMessage = async () => {
 	const data = 'Hello Pelagus'
 	const msg = `0x${Buffer.from(data, 'utf8').toString('hex')}`
-	const signer = '0x06BeDcD422F569735D02293083deFf4B366990fe'
+	const signer = '0x005f644097F8f0E9f996Dca4F4F23aBB6C1Cc8b3'
 
-	await window.ethereum
+	await window.pelagus
 		.request({
 			method: 'personal_sign',
 			params: [data, signer],
@@ -259,24 +259,24 @@ const signTypedData = async () => {
 			name: 'Pelagus Messaging Service',
 			version: '1',
 			chainId: 9000,
-			verifyingContract: '0xa8f7c27264699b489018aadce60436a80781e6da',
+			verifyingContract: '0x0063Cb948Dc92d8B7637ECDfCC7e33580A6c046b',
 		},
 		message: {
 			from: {
 				name: 'Alice',
-				wallet: '0x91344f319b4658f9f9fd3fbfb3f560e55e2a72de',
+				wallet: '0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC',
 			},
 			to: {
 				name: 'Bob',
-				wallet: '0xa844d9a88331e9688d3065f92c11e25ab1e50aa6',
+				wallet: '0x005f644097F8f0E9f996Dca4F4F23aBB6C1Cc8b3',
 			},
 			contents: 'Howdy there, Bob!',
 		},
 	}
-	await window.ethereum
+	await window.pelagus
 		.request({
 			method: 'quai_signTypedData_v4',
-			params: ['0x91344f319b4658f9f9fd3fbfb3f560e55e2a72de', typedData],
+			params: ['0x00735E9B2c731Fd3eCC8129a3653ACb99dF969cC', typedData],
 		})
 		.then((signature) => {
 			// if the request succeeds, the promise resolves to the signature hexadecimal string

--- a/docs/develop/api/quai-provider.md
+++ b/docs/develop/api/quai-provider.md
@@ -4,17 +4,13 @@ title: Pelagus Provider API
 description: Reference for the Pelagus Provider API.
 ---
 
-The Pelagus provider API is a global Javascript API injected into the browser by the extension. The Pelagus provider and API are accessible via the injected `window.ethereum` object, which allows applications to interface with the users and the network.
+The Pelagus provider API is a global Javascript API injected into the browser by the extension. The Pelagus provider and API are accessible via the injected `window.pelagus` object, which allows applications to interface with the users and the network.
 
 ## Properties
 
-### window.ethereum.isPelagus
-
-The `isPelagus` property indicates whether the injected `window.ethereum` is Pelagus. This property is available on page load.
-
 ## Methods
 
-### window.ethereum.request(args)
+### window.pelagus.request(args)
 
 The `request` method is used to submit RPC API requests to Quai Network using Pelagus. The request returns a `Promise` that resolves to the result of the RPC method call. If the request fails, the promise will reject with an error.
 
@@ -24,10 +20,10 @@ interface RequestArguments {
   params?: unknown[] | object;
 }
 
-window.ethereum.request(args: RequestArguments): Promise<unknown>;
+window.pelagus.request(args: RequestArguments): Promise<unknown>;
 ```
 
-Pelagus natively bundles a subset of the [Quai JSON-RPC API](https://docs.quai.network/develop/apis/json-rpc) methods alongside a set of [Pelagus specific methods](./json-rpc-api.md). Methods are always of type `string` and are case-sensitive. The `params` property is optional depending on the method called and can be either an array of parameters or an object of named parameters.
+Pelagus natively bundles a subset of the [Quai JSON-RPC API](https://docs.qu.ai/build/playground/overview) methods alongside a set of [Pelagus specific methods](./json-rpc-api.md). Methods are always of type `string` and are case-sensitive. The `params` property is optional depending on the method called and can be either an array of parameters or an object of named parameters.
 
 
 
@@ -40,19 +36,19 @@ const handleAccountsChanged = (accounts) => {
 	// Handle new accounts or empty return
 }
 // Add listener
-window.ethereum.on('accountsChanged', handleAccountsChanged)
+window.pelagus.on('accountsChanged', handleAccountsChanged)
 // Remove listener
-window.ethereum.removeListener('accountsChanged', handleAccountsChanged)
+window.pelagus.removeListener('accountsChanged', handleAccountsChanged)
 ```
 
-Pelagus event listeners accept two arguments, the first being the event name and the second being a callback function passed to `window.ethereum` when the event is emitted.
+Pelagus event listeners accept two arguments, the first being the event name and the second being a callback function passed to `window.pelagus` when the event is emitted.
 
 ### accountsChanged
 
 The `accountsChanged` event is emitted when the currently connected account changes. The event returns a hexadecimal array of the new connected account.
 
 ```ts
-window.ethereum.on('accountsChanged', handler: (accounts: Array<string>) => void);
+window.pelagus.on('accountsChanged', handler: (accounts: Array<string>) => void);
 ```
 
 The `accountsChanged` event returns the value of the `quai_accounts` RPC method upon the account change. `quai_accounts` returns either an empty array, or an array that contains the addresses of the accounts the caller is permitted to access with the most recently used account first. Callers are identified by their URL origin, which means that all sites with the same origin share the same permissions.
@@ -69,7 +65,7 @@ interface PelagusError extends Error {
 }
 ```
 
-The [`window.ethereum.request(args)`](#windowethereumrequestargs) is the most common method you'll run into errors with when using Pelagus.
+The [`window.pelagus.request(args)`](#windowpelagusrequestargs) is the most common method you'll run into errors with when using Pelagus.
 
 Some common error codes are shown below.
 

--- a/docs/develop/get-started/detecting-pelagus.md
+++ b/docs/develop/get-started/detecting-pelagus.md
@@ -6,57 +6,40 @@ description: Detect Pelagus in your browser and application.
 
 ## Introduction
 
-Similar to other browser extension wallets, Pelagus Wallet injects a unique `window.ethereum` object into the browser. This object can be used to send messages to the wallet, get data from the provider, and handle user actions.
+Similar to other browser extension wallets, Pelagus Wallet injects a unique `window.pelagus` object into the browser. This object can be used to send messages to the wallet, get data from the provider, and handle user actions.
 
 ## Handling Multiple Extensions
 
-Often times, users _have multiple browser extension wallets installed alongside Pelagus_, each with their own injected `ethereum` object. The injection of multiple wallet providers in one browsers can potentially cause collisions or overrides of the Pelagus `window.ethereum` object. To avoid this, it is important to **specifically detect the presence of the Pelagus extension** in your application.
+Often times, users _have multiple browser extension wallets installed alongside Pelagus_, each with their own injected `ethereum` object. Pelagus does inject a `window.ethereum` object as a fallback, but it is always recommended to interact with Pelagus via the `window.pelagus` object.
 
-### The Default Wallet
-
-Pelagus wallet has an option for users to set it as the default wallet. If Pelagus is:
-
-- **Set as the default wallet**: Pelagus will override the `ethereum` object of all other injected wallet providers.
-- **Not set as the default wallet**: Pelagus may be overridden by the `ethereum` object of another wallet provider.
-
-For easy handling of either of the above cases, Pelagus provides a property `isPelagus` in the `window.ethereum` object. You can search for the `isPelagus` property using the following code:
-
-```js
-window.ethereum.providers?.find((p) => p.isPelagus) || window.ethereum;
-```
-
-The above expression will evaluate to the Pelagus provider if it is present.
+Usage of the Pelagus injected `window.ethereum` object alongside other wallet providers in the browser can potentially cause collisions or overrides. To avoid this, it is important to **specifically detect the presence of the Pelagus extension** in your application using `window.pelagus`.
 
 ## Pelagus in Browser
 
-Pelagus can be detected by searching for a provider with the `isPelagus` property in the `window.ethereum` object.
+Pelagus can be detected in the browser via the `window.pelagus` object.
 
 Running the command from above in your browser console will return the Pelagus provider if it is present:
 
 ```js
-> window.ethereum.providers?.find((p) => p.isPelagus) || window.ethereum
+> window.pelagus
 
 // Pelagus is present output
-TallyWindowProvider {_events: {…}, _eventsCount: 0, _maxListeners: undefined, chainId: '0x1', connected: false, …}
+PelagusWindowProvider { … }
 ```
 
-If the value returned is not a `TallyWindowProvider`, then Pelagus is not present in the browser.
+If the value returned is not a `PelagusWindowProvider`, then Pelagus is not present in the browser.
 
 ## Pelagus in Your Application
 
-Inside of your application, you may want to differentiate between Pelagus and other Quai-based wallets. Verify that the provider is Pelagus by checking the `isPelagus` property in the `window.ethereum` object:
+Inside of your application, you may want to differentiate between Pelagus and other Quai-based wallets. Verify that the provider is Pelagus by accessing the `window.pelagus` object.
 
 ```js
 function detectPelagus() {
-	if (window.ethereum) {
-		const provider = window.ethereum.providers?.find((p) => p.isPelagus);
-		if (provider.isPelagus) {
-			// Pelagus detected in the application
-		} else {
-			// Another wallet provider detected
-		}
+	if (window.pelagus) {
+		// Pelagus detected, set provider
+		const provider = window.pelagus
 	} else {
-		// No wallet provider detected
+		// No Pelagus detected
 	}
 }
 ```

--- a/docs/develop/get-started/user-accounts.md
+++ b/docs/develop/get-started/user-accounts.md
@@ -21,18 +21,18 @@ Pelagus has two methods of requesting user accounts:
 
 ## Handling Accounts
 
-Pelagus will always return an array that contains the address of the shard the user is currently connected with. Because Pelagus returns no information regarding the shard that the address maps to, it can be useful to import the `getShardFromAddress` method from the [`quais`](https://www.npmjs.com/package/quais) SDK in order to derive the shard the address is on.
+ Pelagus does not returns any information regarding the zone that a user's connected address address maps to. To determine which zone a user is on it can be useful to use the `getZoneFromAddress` method from the [`quais`](https://www.npmjs.com/package/quais) SDK in order to differentiate which zone the address is on.
 
-An example of address shard determination:
+An example of address zone determination:
 
 ```js title="requestAccounts.js"
-import { getShardFromAddress } from 'quais/lib/utils'
+import { quais } from 'quais'
 
 export const requestAccounts = async () => {
-	await window.ethereum
+	await window.pelagus
 		.request({ method: 'quai_requestAccounts' })
 		.then((accounts) => {
-			const shard = getShardFromAddress(accounts[0])
+			const zone = quais.getZoneFromAddress(accounts[0])
 			const address = {
 				shard: shard,
 				address: accounts[0],

--- a/docs/develop/how-to/send-transaction.md
+++ b/docs/develop/how-to/send-transaction.md
@@ -22,7 +22,7 @@ Transactions should be initiated upon a direct user action, such as clicking a b
 ```js title="TransactionButton.jsx"
 export default const TransactionButton = () => {
 	const sendTransaction = async () => {
-		await window.ethereum
+		await window.pelagus
             .request({
                 method: 'quai_sendTransaction',
                 params: [

--- a/docs/develop/how-to/sign-message.md
+++ b/docs/develop/how-to/sign-message.md
@@ -25,7 +25,7 @@ export default const SignButton = () => {
 	const message = 'hello pelagus';
 
 	const signMessage = async () => {
-		await window.ethereum
+		await window.pelagus
 			.request({
 				method: 'personal_sign',
 				params: [message, accounts[0]],

--- a/docs/wallet/intro.md
+++ b/docs/wallet/intro.md
@@ -9,11 +9,12 @@ title: Introduction
 
 ## What is Quai Network?
 
-Quai is a pre-launch cryptocurrency powered by the Quai Network. Quai Network is the first blockchain protocol that is simultaneously decentralized, censorship resistant, and infinitely scalable. Quai, in contrast to traditional cryptocurrencies, functions as a [network of many interoperable blockchains braided together.](https://docs.quai.network/advanced-introduction/multithreaded-execution) Due to a breakthrough discovery that occurred during research on Proof-of-Work, [Quai Network utilizes a new consensus mechanism, Proof-of-Entropy-Minima (PoEM)](https://arxiv.org/abs/2303.04305), which eliminates all consensus-based forks, and enables all Quai nodes to remain in “perpetual consensus.”
+Quai is a pre-launch cryptocurrency powered by the Quai Network. Quai Network is the first blockchain protocol that is simultaneously decentralized, censorship resistant, and infinitely scalable. Quai, in contrast to traditional cryptocurrencies, functions as a [network of many interoperable blockchains braided together.](https://docs.qu.ai/learn/advanced-introduction/multithreaded-execution) Due to a breakthrough discovery that occurred during research on Proof-of-Work, [Quai Network utilizes a new consensus mechanism, Proof-of-Entropy-Minima (PoEM)](https://arxiv.org/abs/2303.04305), which eliminates all consensus-based forks, and enables all Quai nodes to remain in “perpetual consensus.”
 
-The use of an interwoven braid of blockchains means that each Pelagus Wallet account controls many blockchain accounts — one for each Quai blockchain. You can read more about Quai’s multichain architecture and sharded address space in [the Quai docs](https://docs.quai.network/introduction/quai-network).
+The use of an interwoven braid of blockchains means that each Pelagus Wallet account controls many blockchain accounts — one for each Quai blockchain. You can read more about Quai’s multichain architecture and sharded address space in [the Quai docs](https://docs.qu.ai/learn/introduction).
 
 ## Why Pelagus Wallet?
+
 Pelagus has been specifically configured to function with Quai Network's unique multi-chain artchitecture. Each Pelagus seed phrase can be used to simultaneously manage many accounts on all different chains within Quai Network.
 
 Pelagus Wallet is a browser extension for storing tokens and interacting with Quai Network. Being a browser extension makes Pelagus easy to use, especially for those who have used browser extension wallets like MetaMask before. Pelagus makes it simple to do more than just store tokens; you can also interact with smart contracts and dapps. It's user-friendly and designed to be simple and straightforward, making it a great tool for both beginners and experienced crypto users.

--- a/docs/wallet/use-pelagus/installation.md
+++ b/docs/wallet/use-pelagus/installation.md
@@ -5,7 +5,7 @@ title: Install Pelagus
 
 ## Installation
 
-Pelagus wallet can be downloaded from the [Chrome Web Store](https://chrome.google.com/webstore/detail/pelagus/gaegollnpijhedifeeeepdoffkgfcmbc). The extension is supported on all Chromium-based browsers, including Brave, Opera, and Microsoft Edge.
+Pelagus wallet can be downloaded from the [Chrome Web Store](https://chromewebstore.google.com/detail/pelagus/nhccebmfjcbhghphpclcfdkkekheegop). The extension is supported on all Chromium-based browsers, including Brave, Opera, and Microsoft Edge.
 
 <p align="center">
 


### PR DESCRIPTION
- Update all instances of `window.ethereum` to `window.pelagus`
- Update the connection logic to use `window.pelagus`
- Update links and page references to newest
- Remove sections related to handling `window.ethereum` conflicts and Pelagus identification
- Update all addresses to golden age addresses
- Update references to older quais.js functions